### PR TITLE
Fix url option actualVersion argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ so you might see some errors in the output, that's probably fine.
 If you only want to generate types for **one** service (i.e., Google Sheets)
 use the following command:
 ```sh
-ts-node -T src/cli.ts --out ./types --service sheets
+npx ts-node -T src/cli.ts --out ./types --service sheets
 ```
 where "sheets" is the name of the service. You can find all names 
 [here](https://www.googleapis.com/discovery/v1/apis)
 
 Alternatively, you can compile the project first:
 ```sh
-tsc -p .
+npx tsc
 ```
 and then run it using node:
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ const app = new App(params.out);
 
 if (params.url) {
   app
-    .processService(params.url, params.all || false)
+    .processService(params.url, true)
     .then(() => console.log('Done'), error => console.error(error));
 } else {
   app


### PR DESCRIPTION
* Always sets `actualVersion` to `true` when passing in `url` option
* Adds [`npx`](https://www.npmjs.com/package/npx) to README
* Used to generate https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41311:

    ```
    $ npx ts-node -T src/cli.ts --out ~/dev/git/DefinitelyTyped/types --url "https://photoslibrary.googleapis.com/\$discovery/rest?version=v1"
    Output directory: /Users/namoscato/dev/git/DefinitelyTyped/types
    base directory: /Users/namoscato/dev/git/DefinitelyTyped/types
    typings directory: /Users/namoscato/dev/git/DefinitelyTyped/types

    Generating photoslibrary:v1 definitions...
    Done
    ```