### PR TITLE
Add nvm and npm install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ using [Google API discovery](https://developers.google.com/discovery/) service.
 
 ### Generating types
 
+First of all, you may run `nvm i` (if [installed](https://github.com/nvm-sh/nvm#install--update-script))
+
+Install dependecies:
+```sh
+npm install
+```
+
 Run program:
 ```sh
 npm start


### PR DESCRIPTION
When running `npx ts-node xxx.ts` on my server, I found out that it requires `typescript` to be installed beforehand:
```
npx: installed 8 in 2.379s
Cannot find module 'typescript'
Require stack:
- /home/maxim/.npm/_npx/10408/lib/node_modules/ts-node/dist/index.js
- /home/maxim/.npm/_npx/10408/lib/node_modules/ts-node/dist/bin.js
```

So, I added instructions to readme to run `nvm i` (optionally) and then run `npm install` before running any other scripts.