### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,5 @@ jobs:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         PUBLISH_BRANCH: types
         PUBLISH_DIR: ./types
+      with:
+        emptyCommits: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install and build
+      run: |
+        npm ci
+        npm start
+      env:
+        CI: true
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v2
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        PUBLISH_BRANCH: types
+        PUBLISH_DIR: ./types


### PR DESCRIPTION
Relates to https://github.com/Maxim-Mazurok/google-api-typings-generator/issues/15.

Generates all types and pushes to a `types` branch when generator source code hits `master`.

Example:

* [workflow run](https://github.com/namoscato/google-api-typings-generator/runs/380525050)
* [generated output](https://github.com/namoscato/google-api-typings-generator/tree/types)

### @Maxim-Mazurok's TODOs:

- [x] Setup an `ACTIONS_DEPLOY_KEY` SSH deploy key for this repository per [these instructions](https://github.com/peaceiris/actions-gh-pages#1-add-ssh-deploy-key)
- [x] Create a [branch protection rule](https://help.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests) for the `types` branch to prevent accidental deletion