### PR TITLE
Fix empty request bodies

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,6 @@ import * as request from 'request';
 import * as sortObject from 'deep-sort-object';
 import { getResourceTypeName, parseVersion } from './utils';
 import JsonSchema = gapi.client.discovery.JsonSchema;
-import RestMethod = gapi.client.discovery.RestMethod;
 import RestResource = gapi.client.discovery.RestResource;
 import RestDescription = gapi.client.discovery.RestDescription;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,11 @@ import * as request from 'request';
 // tslint:disable-next-line:ban-ts-ignore
 // @ts-ignore
 import * as sortObject from 'deep-sort-object';
-import { parseVersion } from './utils';
+import { getResourceTypeName, parseVersion } from './utils';
+import JsonSchema = gapi.client.discovery.JsonSchema;
+import RestMethod = gapi.client.discovery.RestMethod;
+import RestResource = gapi.client.discovery.RestResource;
+import RestDescription = gapi.client.discovery.RestDescription;
 
 const typesMap: { [key: string]: string } = {
   integer: 'number',
@@ -256,6 +260,7 @@ class TypescriptTextWriter implements TypescriptTextWriter {
     parameters: Array<{
       parameter: string;
       type: string | TypescriptWriterCallback;
+      required: boolean;
     }>,
     returnType: string,
     singleLine = false
@@ -263,7 +268,7 @@ class TypescriptTextWriter implements TypescriptTextWriter {
     this.writer.startIndentedLine(`${name}(`);
 
     _.forEach(parameters, (parameter, index) => {
-      this.write(parameter.parameter + ': ');
+      this.write(`${parameter.parameter}${parameter.required ? '' : '?'}: `);
       this.write(parameter.type);
 
       if (index + 1 < parameters.length) {
@@ -280,7 +285,6 @@ class TypescriptTextWriter implements TypescriptTextWriter {
     this.writer.write(`): ${returnType};`);
 
     this.endLine();
-    //this.writer.writeLine(`${name}(${parameters.map(p => p.parameter + ": " + p.type).join(", ")}): ${returnType};`);
   }
 
   writeLine(chunk = '') {
@@ -418,7 +422,7 @@ function loadTemplate(name: string) {
   } else if (fs.existsSync(path.join('..', name))) {
     filename = path.join('..', name);
   } else {
-    throw Error(`Can\'t find ${name} file template`);
+    throw Error(`Can't find ${name} file template`);
   }
 
   doT.templateSettings.strip = false;
@@ -462,25 +466,45 @@ export class App {
     return dir;
   }
 
-  private static getResourceTypeName(resourceName: string) {
-    resourceName = resourceName
-      .split('-')
-      .map(x => `${x[0].toUpperCase()}${x.substring(1)}`)
-      .join('');
-    return (
-      resourceName[0].toUpperCase() + resourceName.substring(1) + 'Resource'
-    );
+  /**
+   * Creates a callback that writes request parameters.
+   */
+  private static createRequestParameterWriterCallback(
+    parameters: Record<string, JsonSchema>,
+    schemas: Record<string, JsonSchema>,
+    ref?: string
+  ) {
+    return function requestParameterWriterCallback(
+      writer: TypescriptTextWriter
+    ) {
+      writer.anonymousType(() => {
+        _.forEach(parameters, (data, key) => {
+          if (data.description) {
+            writer.comment(formatComment(data.description));
+          }
+
+          writer.property(key, getType(data, schemas), Boolean(data.required));
+        });
+
+        if (ref) {
+          writer.comment('Request body');
+          writer.property('resource', ref, true);
+        }
+      });
+    };
   }
 
-  // writes specified resource definition
+  /**
+   * Writes specified resource definition.
+   */
   private writeResources(
     out: TypescriptTextWriter,
-    resources: Record<string, gapi.client.discovery.RestResource>,
-    parameters: Record<string, gapi.client.discovery.JsonSchema> = {},
-    schemas: Record<string, gapi.client.discovery.JsonSchema>
+    resources: Record<string, RestResource>,
+    parameters: Record<string, JsonSchema> = {},
+    schemas: Record<string, JsonSchema>
   ) {
     _.forEach(resources, (resource, resourceName) => {
-      const resourceInterfaceName = App.getResourceTypeName(resourceName);
+      const resourceInterfaceName = getResourceTypeName(resourceName);
 
       if (resource.resources) {
         this.writeResources(out, resource.resources, parameters, schemas);
@@ -491,73 +515,49 @@ export class App {
           if (method.description) {
             out.comment(formatComment(method.description));
           }
-          const requestParameters: Record<
-            string,
-            gapi.client.discovery.JsonSchema
-          > = sortObject({ ...parameters, ...method.parameters });
-          const hasRequestRef = method.request && method.request['$ref'];
-          if (
-            !(requestParameters.hasOwnProperty('resource') && hasRequestRef)
-          ) {
-            // no resource param and no body at the same time -> generate x(request)
+
+          const requestRef = method.request?.$ref;
+          const requestParameters: Record<string, JsonSchema> = sortObject({
+            ...parameters,
+            ...method.parameters,
+          });
+
+          if (!requestParameters.resource || !requestRef) {
+            // generate method(request)
             out.method(
               formatPropertyName(checkExists(getName(method.id))),
               [
                 {
                   parameter: 'request',
-                  type: (writer: TypescriptTextWriter) => {
-                    writer.anonymousType(() => {
-                      _.forEach(requestParameters, (data, key) => {
-                        if (data.description) {
-                          writer.comment(formatComment(data.description));
-                        }
-                        writer.property(
-                          key,
-                          getType(data, schemas),
-                          data.required || false
-                        );
-                      });
-
-                      if (method.request && method.request['$ref']) {
-                        writer.comment('Request body');
-                        writer.property(
-                          'resource',
-                          method.request['$ref'],
-                          true
-                        );
-                      }
-                    });
-                  },
+                  type: App.createRequestParameterWriterCallback(
+                    requestParameters,
+                    schemas,
+                    requestRef
+                  ),
+                  required: Boolean(requestRef),
                 },
               ],
               getMethodReturn(method, schemas)
             );
           }
-          if (method.request && method.request['$ref']) {
-            // has body -> generate x(request, body)
+
+          if (requestRef) {
+            // generate method(request, body)
             out.method(
               formatPropertyName(checkExists(getName(method.id))),
               [
                 {
                   parameter: 'request',
-                  type: (writer: TypescriptTextWriter) => {
-                    writer.anonymousType(() => {
-                      _.forEach(requestParameters, (data, key) => {
-                        if (data.description) {
-                          writer.comment(formatComment(data.description));
-                        }
-                        writer.property(
-                          key,
-                          getType(data, schemas),
-                          data.required || false
-                        );
-                      });
-                    });
-                  },
+                  type: App.createRequestParameterWriterCallback(
+                    requestParameters,
+                    schemas
+                  ),
+                  required: true,
                 },
                 {
                   parameter: 'body',
-                  type: method.request['$ref'],
+                  type: requestRef,
+                  required: true,
                 },
               ],
               getMethodReturn(method, schemas)
@@ -567,7 +567,7 @@ export class App {
 
         if (resource.resources) {
           _.forEach(resource.resources, (_, childResourceName) => {
-            const childResourceInterfaceName = App.getResourceTypeName(
+            const childResourceInterfaceName = getResourceTypeName(
               childResourceName
             );
             out.property(childResourceName, childResourceInterfaceName);
@@ -641,8 +641,8 @@ export class App {
       writer.method(
         `function load`,
         [
-          { parameter: `name`, type: `"${api.name}"` },
-          { parameter: `version`, type: `"${api.version}"` },
+          { parameter: `name`, type: `"${api.name}"`, required: true },
+          { parameter: `version`, type: `"${api.version}"`, required: true },
         ],
         'PromiseLike<void>',
         true
@@ -651,9 +651,9 @@ export class App {
       writer.method(
         `function load`,
         [
-          { parameter: `name`, type: `"${api.name}"` },
-          { parameter: `version`, type: `"${api.version}"` },
-          { parameter: `callback`, type: `() => any` },
+          { parameter: `name`, type: `"${api.name}"`, required: true },
+          { parameter: `version`, type: `"${api.version}"`, required: true },
+          { parameter: `callback`, type: `() => any`, required: true },
         ],
         'void',
         true
@@ -700,9 +700,7 @@ export class App {
             if (resourceName !== 'debugger') {
               writer.endLine();
               writer.writeLine(
-                `const ${resourceName}: ${App.getResourceTypeName(
-                  resourceName
-                )};`
+                `const ${resourceName}: ${getResourceTypeName(resourceName)};`
               );
             }
           });
@@ -930,7 +928,7 @@ export class App {
 
   private writeResourceTests(
     scope: TypescriptTextWriter,
-    api: gapi.client.discovery.RestDescription,
+    api: RestDescription,
     ancestors: string,
     resourceName: string,
     resource: gapi.client.discovery.RestResource
@@ -938,17 +936,23 @@ export class App {
     _.forEach(resource.methods, (method, methodName) => {
       scope.comment(method.description);
       scope.newLine(`await ${ancestors}.${resourceName}.${methodName}(`);
-      const params:
-        | Record<string, gapi.client.discovery.JsonSchema>
-        | undefined = resource.methods![methodName].parameters;
+
+      const params: Record<string, JsonSchema> | undefined = method.parameters;
+      const ref = method.request?.$ref;
+
       if (params) {
         scope.scope(() => {
           this.writeProperties(scope, api, params);
         });
       }
-      const ref = method.request?.$ref;
-      if (ref != null) {
+
+      if (ref) {
+        if (!params) {
+          scope.write(`{} `);
+        }
+
         scope.write(`, `);
+
         this.writeSchemaRef(scope, api, ref);
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,3 +8,15 @@ export function parseVersion(version: string) {
 
   return matches ? `${matches[1] || 0}.${matches[2] || 0}` : '0.0';
 }
+
+/**
+ * Returns the capitalized name of the TypeScript interface for the specified resource.
+ */
+export function getResourceTypeName(resourceName: string) {
+  resourceName = resourceName
+    .split('-')
+    .map(x => `${x[0].toUpperCase()}${x.substring(1)}`)
+    .join('');
+
+  return `${resourceName[0].toUpperCase()}${resourceName.substring(1)}Resource`;
+}

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,15 +1,15 @@
 import 'jasmine';
 import * as _ from 'lodash';
 import * as assert from 'assert';
-import {getResourceTypeName, parseVersion} from '../src/utils';
+import { getResourceTypeName, parseVersion } from '../src/utils';
 
 describe('parseVersion', () => {
   const expectations = {
-    'v1': '1.0',
+    v1: '1.0',
     'v1.2': '1.2',
     'v1.2beta3': '1.2',
-    'vm_beta': '0.0',
-    'invalid': '0.0',
+    vm_beta: '0.0',
+    invalid: '0.0',
   };
 
   _.forEach(expectations, (expected, given) => {
@@ -21,8 +21,8 @@ describe('parseVersion', () => {
 
 describe('getResourceTypeName', () => {
   const expectations = {
-    'marketplaceprivateauction': 'MarketplaceprivateauctionResource',
-    'marketplacePrivateAuction': 'MarketplacePrivateAuctionResource',
+    marketplaceprivateauction: 'MarketplaceprivateauctionResource',
+    marketplacePrivateAuction: 'MarketplacePrivateAuctionResource',
     'marketplace-privateauction': 'MarketplacePrivateauctionResource',
     'marketplace-private-auction': 'MarketplacePrivateAuctionResource',
   };

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,7 +1,7 @@
 import 'jasmine';
 import * as _ from 'lodash';
 import * as assert from 'assert';
-import { parseVersion } from '../src/utils';
+import {getResourceTypeName, parseVersion} from '../src/utils';
 
 describe('parseVersion', () => {
   const expectations = {
@@ -15,6 +15,21 @@ describe('parseVersion', () => {
   _.forEach(expectations, (expected, given) => {
     it(`should parse: ${given}`, () => {
       assert.equal(parseVersion(given), expected);
+    });
+  });
+});
+
+describe('getResourceTypeName', () => {
+  const expectations = {
+    'marketplaceprivateauction': 'MarketplaceprivateauctionResource',
+    'marketplacePrivateAuction': 'MarketplacePrivateAuctionResource',
+    'marketplace-privateauction': 'MarketplacePrivateauctionResource',
+    'marketplace-private-auction': 'MarketplacePrivateAuctionResource',
+  };
+
+  _.forEach(expectations, (expected, given) => {
+    it(`should convert: ${given}`, () => {
+      assert.equal(getResourceTypeName(given), expected);
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "."
   },
   "include": [
     "src/**/*.ts",
-    "test/**/*.ts"
+    "tests/**/*.ts"
   ]
 }


### PR DESCRIPTION
Fixes #51

* Make request argument optional for empty bodies
* Minimize duplication via RequestParameterWriterCallback
* Unit test getResourceTypeName
* Reverts https://github.com/Maxim-Mazurok/google-api-typings-generator/pull/52 `rootDir` change