### PR TITLE
Add Apigee support

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -399,12 +399,16 @@ function getMethodReturn(
   const name = schemas['Request'] ? 'client.Request' : 'Request';
 
   if (method.response) {
-    const schema = schemas[checkExists(method.response.$ref)];
+    if (method.response.$ref) {
+      const schema = schemas[method.response.$ref];
 
-    if (schema && !_.isEmpty(schema.properties)) {
-      return `${name}<${method.response.$ref}>`;
+      if (schema && !_.isEmpty(schema.properties)) {
+        return `${name}<${method.response.$ref}>`;
+      } else {
+        return `${name}<{}>`;
+      }
     } else {
-      return `${name}<{}>`;
+      return `${name}<${getType(method.response, schemas)}>`;
     }
   } else {
     return `${name}<void>`;


### PR DESCRIPTION
This PR potentially will close #88 and will close #92 

Currently, it seems like the API definition is either WIP or uses architecture which is not compatible with our code.

Also, it seems like there's no client-side libraries for Apigee (yet), so we're not going to support it for now. If you think that we should - please, comment.

----

Currently I've added a change to do this:
```diff
  /** List key value maps in an api proxy. */
  list(request?: {
     //...
- }): Request<void>;
+ }): Request<any[]>;
```
when generating typings for this:
```json5
"list": {
    "response": {
        "type": "array",
        "items": {
            "type": "any"
        }
    },
    //...
    "description": "List key value maps in an api proxy."
}
```

----

Stuff that still needs to be done (not full list):
- [ ] Handle `attributes`:
```json5
"apiproducts": {
    "methods": {
        //...
        "attributes": {} // <-- first attributes
    },
    "resources": {
        "attributes": {}  // <-- duplicate attributes
    }
},
```
- [ ] To be continued (maybe)