### PR TITLE
Log files with linting errors for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /types
 /dist
+/.tmp

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,15 @@
 import doT from 'dot';
 import fs from 'fs';
 import _ from 'lodash';
-import path from 'path';
+import path, { resolve, join, basename } from 'path';
 import request from 'request';
 import sortObject from 'deep-sort-object';
 import { getResourceTypeName, parseVersion } from './utils';
 import JsonSchema = gapi.client.discovery.JsonSchema;
 import RestResource = gapi.client.discovery.RestResource;
 import RestDescription = gapi.client.discovery.RestDescription;
+
+export const tmpDirPath = resolve(__dirname, './../.tmp');
 
 const typesMap: { [key: string]: string } = {
   integer: 'number',
@@ -124,12 +126,11 @@ function formatPropertyName(name: string) {
   return name;
 }
 
-function ensureDirectoryExists(directory: string) {
+const ensureDirectoryExists = (directory: string) => {
   if (!fs.existsSync(directory)) {
-    ensureDirectoryExists(path.dirname(directory));
-    fs.mkdirSync(directory);
+    fs.mkdirSync(directory, { recursive: true });
   }
-}
+};
 
 class TypescriptTextWriter implements TypescriptTextWriter {
   constructor(private writer: IndentedTextWriter) {}
@@ -447,13 +448,11 @@ export class App {
   constructor(private base = __dirname + '/../types/') {
     this.typingsDirectory = base;
 
-    if (!fs.existsSync(this.base)) {
-      fs.mkdirSync(this.base);
-    }
+    ensureDirectoryExists(this.base);
 
-    if (!fs.existsSync(this.typingsDirectory)) {
-      fs.mkdirSync(this.typingsDirectory);
-    }
+    ensureDirectoryExists(this.typingsDirectory);
+
+    ensureDirectoryExists(tmpDirPath);
 
     console.log(`base directory: ${this.base}`);
     console.log(`typings directory: ${this.typingsDirectory}`);
@@ -462,7 +461,7 @@ export class App {
 
   static parseOutPath(dir: string) {
     if (!fs.existsSync(dir)) {
-      throw new Error(`Directory not found: ${dir}`);
+      ensureDirectoryExists(dir);
     }
 
     return dir;
@@ -773,6 +772,11 @@ export class App {
     const destinationDirectory = this.getTypingsDirectory(
       api.name,
       actualVersion ? null : api.version
+    );
+
+    fs.writeFileSync(
+      join(tmpDirPath, `${basename(destinationDirectory)}.json`),
+      JSON.stringify(api)
     );
 
     ensureDirectoryExists(destinationDirectory);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true
   },
   "include": [
+    "bin/**/*",
     "src/**/*",
     "tests/**/*"
   ]


### PR DESCRIPTION
Closes #89 by adding additional logging during build process, so that such errors can be properly investigated.
Now when linter fails - it outputs JSON, d.ts and test file for failed API.
Also, now directories are getting created recursively in case if there's no such dir, making things easier.
And now `bin` folder is included in `tsconfig.json` so that `gts` will check and fix formatting in the `lint.ts` script.