### PR TITLE
Prototype build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,6 @@ jobs:
       run: npm run lint
       env:
         GAPI_MAX_PARALLEL: 3
-    - name: Upload types
-      uses: actions/upload-artifact@v1
-      with:
-        name: types
-        path: types
     - name: Copy discovery service response
       if: failure()
       run: cp .tmp/${{ env.FAILED_TYPE }}.json types/${{ env.FAILED_TYPE }}
@@ -40,6 +35,11 @@ jobs:
       with:
         name: ${{ env.FAILED_TYPE }}
         path: types/${{ env.FAILED_TYPE }}
+    - name: Upload types
+      uses: actions/upload-artifact@v1
+      with:
+        name: types
+        path: types
 
   deploy:
     needs: generate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,24 +9,35 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [12.x]
-
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install, build and lint
-      run: |
-        npm ci
-        npm start
-        npm run lint
+    - run: npm ci
+    - name: Generate types
+      run: npm start
+    - run: npm run lint
       env:
-        CI: true
+        GAPI_MAX_PARALLEL: 3
+    - name: Upload types
+      uses: actions/upload-artifact@v1
+      with:
+        name: types
+        path: types
+
+  deploy:
+    needs: generate
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download types
+      uses: actions/download-artifact@v1
+      with:
+        name: types
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v2
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,15 @@ jobs:
       with:
         name: types
         path: types
+    - name: Copy discovery service response
+      if: failure()
+      run: cp .tmp/${{ env.FAILED_TYPE }}.json types/${{ env.FAILED_TYPE }}
+    - name: Upload failed type
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: ${{ env.FAILED_TYPE }}
+        path: types/${{ env.FAILED_TYPE }}
 
   deploy:
     needs: generate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
+    - name: Install dependencies
+      run: npm ci
     - name: Generate types
       run: npm start
-    - run: npm run lint
+    - name: Lint types
+      run: npm run lint
       env:
         GAPI_MAX_PARALLEL: 3
     - name: Upload types

--- a/.github/workflows/ci-lint-types.yml
+++ b/.github/workflows/ci-lint-types.yml
@@ -22,3 +22,12 @@ jobs:
       run: npm run lint
       env:
         GAPI_MAX_PARALLEL: 3
+    - name: Copy discovery service response
+      if: failure()
+      run: cp .tmp/${{ env.FAILED_TYPE }}.json types/${{ env.FAILED_TYPE }}
+    - name: Upload failed type
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: ${{ env.FAILED_TYPE }}
+        path: types/${{ env.FAILED_TYPE }}

--- a/.github/workflows/ci-lint-types.yml
+++ b/.github/workflows/ci-lint-types.yml
@@ -5,22 +5,18 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [12.x]
-
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and lint
-      run: |
-        npm ci
-        npm start
-        npm run lint
+    - run: npm ci
+    - name: Generate types
+      run: npm start
+    - run: npm run lint
       env:
-        CI: true
         GAPI_MAX_PARALLEL: 3

--- a/.github/workflows/ci-lint-types.yml
+++ b/.github/workflows/ci-lint-types.yml
@@ -14,9 +14,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
+    - name: Install dependencies
+      run: npm ci
     - name: Generate types
       run: npm start
-    - run: npm run lint
+    - name: Lint types
+      run: npm run lint
       env:
         GAPI_MAX_PARALLEL: 3

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -5,20 +5,14 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [12.x]
-
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install and test
-      run: |
-        npm ci
-        npm test
-      env:
-        CI: true
+    - run: npm ci
+    - run: npm test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,5 +14,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm test
+    - name: Install dependencies
+      run: npm ci
+    - name: Run tests
+      run: npm test

--- a/bin/lint.ts
+++ b/bin/lint.ts
@@ -1,7 +1,6 @@
-import { readdirSync, readFileSync } from 'fs';
+import { readdirSync } from 'fs';
 import { join, basename } from 'path';
 import runAll from 'npm-run-all';
-import { tmpDirPath } from '../src/app';
 
 const MAX_PARALLEL = Number(process.env.GAPI_MAX_PARALLEL) || 1;
 
@@ -33,19 +32,11 @@ runAll([scripts.shift()], options) // run first synchronously to install TypeScr
     if (error.results) {
       const results: Array<{ name: string; code: number }> = error.results;
       const failedType = results.find(result => result.code === 1);
+
       if (failedType) {
-        const typeDir = basename(failedType.name);
-        console.log('JSON API definitions:');
-        console.log(
-          readFileSync(join(tmpDirPath, `${typeDir}.json`)).toString()
-        );
-        console.log('Generated index.d.ts:');
-        console.log(readFileSync(join(path, typeDir, 'index.d.ts')).toString());
-        console.log('Generated tests:');
-        console.log(
-          readFileSync(join(path, typeDir, `${typeDir}-tests.ts`)).toString()
-        );
+        console.log(`::set-env name=FAILED_TYPE::${basename(failedType.name)}`);
       }
     }
+
     process.exit(1);
   });


### PR DESCRIPTION
This doesn't buy us much but also doesn't hurt in my opinion. I mostly wanted to prototype [artifact functionality](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts) mentioned in https://github.com/Maxim-Mazurok/google-api-typings-generator/pull/96#discussion_r395990777. If we like this approach, we might consider uploading an artifact when linting fails to minimize some of the verbose stdout.

Specifically, this:

* Separates GitHub Action npm commands into separate steps
* Sets `GAPI_MAX_PARALLEL: 3` in `build / generate` job
* Uploads generated types as an artifact in `build / generate` before deploying*

*I [tested this](https://github.com/namoscato/google-api-typings-generator/runs/524089877?check_suite_focus=true) on a forked repository; here's what it looks like:

<img width="401" alt="Screen Shot 2020-03-21 at 10 46 39 AM" src="https://user-images.githubusercontent.com/847532/77228964-4614f600-6b61-11ea-8d29-229509a8882c.png">
