### PR TITLE
Don't open PRs for revision-only changes

### DIFF
--- a/bin/auto-update/gitHelpers.ts
+++ b/bin/auto-update/gitHelpers.ts
@@ -1,6 +1,7 @@
 import {join} from 'path';
 import {Settings} from './index';
 import {Git} from './git';
+import {revisionPrefix} from '../../src/app';
 
 export class GitHelpers {
   readonly settings: Settings;
@@ -10,6 +11,17 @@ export class GitHelpers {
     this.settings = settings;
     this.git = git;
   }
+
+  onlyRevisionChanged = async (type: string): Promise<boolean> => {
+    const cmd = `git diff master..origin/${type} --unified=0`;
+    const diff = (await this.git.sh.trySh(cmd)).stdout
+      .split('\n')
+      .splice(5)
+      .join('\n');
+    return new RegExp(
+      `^-${revisionPrefix}\\d+\\n\\+${revisionPrefix}\\d+\\n$`
+    ).test(diff);
+  };
 
   setConfig = async (): Promise<void> => {
     const {userEmail, userName} = this.settings;

--- a/bin/auto-update/index.ts
+++ b/bin/auto-update/index.ts
@@ -105,7 +105,12 @@ process.on('unhandledRejection', reason => {
   await git.push({all: true, force: true}); // pushes to fork
 
   for (const type of changedTypes) {
-    if (whiteListedTypes.indexOf(type) === -1) continue;
+    if (
+      whiteListedTypes.indexOf(type) === -1 ||
+      (await gitHelpers.onlyRevisionChanged(type))
+    ) {
+      continue;
+    }
 
     await gitHelpers.openPRIfItDoesNotExist(type);
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,7 @@ type DirectoryList = gapi.client.discovery.DirectoryList;
 
 export const typingsPrefix = 'gapi.client.';
 export const tmpDirPath = resolve(__dirname, './../.tmp');
+export const revisionPrefix = '// Revision: ';
 
 const eachLine: (
   ...args: Parameters<LineReader['eachLine']>
@@ -625,7 +626,7 @@ export class App {
       '// In case of any problems please post issue to https://github.com/Maxim-Mazurok/google-api-typings-generator'
     );
     writer.writeLine(`// Generated from: ${url}`);
-    writer.writeLine(`// Revision: ${api.revision}`);
+    writer.writeLine(`${revisionPrefix}${api.revision}`);
     writer.writeLine();
     writer.referenceTypes('gapi.client');
 
@@ -771,8 +772,8 @@ export class App {
         path.join(destinationDirectory, 'index.d.ts'),
         {},
         line => {
-          if (line.startsWith('// Revision: ')) {
-            const match = line.match(/^\/\/ Revision: (\d+)$/);
+          if (line.startsWith(revisionPrefix)) {
+            const match = line.match(new RegExp(`^${revisionPrefix}(\\d+)$`));
             if (match !== null && match.length === 2) {
               existingRevision = Number(match[1]);
               return false;


### PR DESCRIPTION
Fixes #138 (based on #150)
Compares type definitions in master and in our branch, and only opens new PRs to DT if something changed apart from the Revision number.