### PR TITLE
Fix linting on windows

### DIFF
--- a/bin/lint.ts
+++ b/bin/lint.ts
@@ -17,7 +17,7 @@ console.log(`Reading project directories in ${path}...`);
 
 const scripts = readdirSync(path, {withFileTypes: true})
   .filter(dir => dir.isDirectory())
-  .map(dir => `dtslint ${join(path, dir.name)}`);
+  .map(dir => `dtslint "${join(path, dir.name)}"`);
 
 const options = {
   maxParallel: MAX_PARALLEL,


### PR DESCRIPTION
Wraps file path for `dtslint` in quotes to work on Windows PowerShell 7.
Fixes https://github.com/Maxim-Mazurok/google-api-typings-generator/issues/298