### PR TITLE
Handle banned types

### DIFF
--- a/bin/auto-update/config.ts
+++ b/bin/auto-update/config.ts
@@ -1,0 +1,8 @@
+export const supportedApis = [
+  'sheets',
+  'drive',
+  'classroom',
+  'calendar',
+  'storage',
+  'discovery',
+];

--- a/bin/auto-update/index.ts
+++ b/bin/auto-update/index.ts
@@ -4,6 +4,7 @@ import {Git, Settings as GitSettings} from './git';
 import {Helpers, tmpBranchNameFunc} from './helpers';
 import {GitHelpers} from './gitHelpers';
 import {TYPE_PREFIX} from '../../src/utils';
+import {supportedApis} from './config';
 
 if (!process.env.GH_AUTH_TOKEN) {
   throw new Error('Please, set env var: GH_AUTH_TOKEN');
@@ -41,14 +42,7 @@ const settings: Settings = {
   templateUpdateLabel: 'DT PR template update',
 };
 
-const supportedApis = [
-  'sheets',
-  'drive',
-  'classroom',
-  'calendar',
-  'storage',
-  'discovery',
-].map(x => `${TYPE_PREFIX}${x}`);
+const supportedTypes = supportedApis.map(x => `${TYPE_PREFIX}${x}`);
 
 const sh = new SH(settings.dtForkPath);
 const git = new Git(sh, settings);
@@ -112,7 +106,7 @@ process.on('unhandledRejection', reason => {
 
   for (const type of changedTypes) {
     if (
-      supportedApis.indexOf(type) === -1 ||
+      supportedTypes.indexOf(type) === -1 ||
       (await gitHelpers.onlyRevisionChanged(type))
     ) {
       continue;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import program from 'commander';
 import {App} from './app';
 import {getProxySettings, ProxySettings} from 'get-proxy-settings';
-import {getMaxLineLength} from './utils';
+import {getBannedTypes, getMaxLineLength} from './utils';
 
 process.on('unhandledRejection', reason => {
   throw reason;
@@ -40,6 +40,7 @@ console.info(`Output directory: ${params.out}`);
     proxy: bestProxy,
     typesDirectory: params.out,
     maxLineLength: getMaxLineLength(),
+    bannedTypes: await getBannedTypes(),
     owners: [
       'Maxim Mazurok <https://github.com/Maxim-Mazurok>',
       'Google API Typings Generator <https://github.com/google-api-typings-generator>',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import program from 'commander';
 import {App} from './app';
-import {getProxySettings, ProxySettings} from 'get-proxy-settings';
+import {getProxySettings} from 'get-proxy-settings';
 import {getBannedTypes, getMaxLineLength} from './utils';
 
 process.on('unhandledRejection', reason => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,3 +62,12 @@ export function getMaxLineLength(): number {
     ? dtslintConfig.rules['max-line-length'][1]
     : dtslintConfig.rules['max-line-length'][1].limit;
 }
+
+/**
+ * Loads default tslint config to get banned types from `ban-types` rule
+ */
+export async function getBannedTypes(): Promise<string[]> {
+  const tslintAll = await import('../node_modules/tslint/lib/configs/all');
+  const options = tslintAll.rules['ban-types'].options;
+  return options.length || options[0].length ? options.map(x => x[0]) : [];
+}

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -3,10 +3,10 @@ import {supportedApis} from '../bin/auto-update/config';
 import {excludedApis} from '../src/app';
 
 describe('Config validation', () => {
-  it('Excluded and supported APIs should not intersect', () => {
-    const intersect = supportedApis.some(supportedApi =>
+  it('Excluded and supported APIs should not overlap', () => {
+    const overlap = supportedApis.some(supportedApi =>
       excludedApis.includes(supportedApi)
     );
-    assert.strictEqual(intersect, false);
+    assert.strictEqual(overlap, false);
   });
 });

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import {supportedApis} from '../bin/auto-update/config';
+import {excludedApis} from '../src/app';
+
+describe('Config validation', () => {
+  it('Excluded and supported APIs should not intersect', () => {
+    const intersect = supportedApis.some(supportedApi =>
+      excludedApis.includes(supportedApi)
+    );
+    assert.strictEqual(intersect, false);
+  });
+});

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,3 +1,4 @@
+import {sep as pathSeparator} from 'path';
 import _ from 'lodash';
 import assert from 'assert';
 import {
@@ -46,7 +47,10 @@ describe('getTypeDirectory', () => {
 
   describe('with version', () => {
     it('should return name', () => {
-      assert.strictEqual('gapi.client.API/v1', getTypeDirectory('API', 'v1'));
+      assert.strictEqual(
+        `gapi.client.API${pathSeparator}v1`,
+        getTypeDirectory('API', 'v1')
+      );
     });
   });
 });


### PR DESCRIPTION
Get banned types, such as `Object` from tslint config, and add `tslint:disable-next-line` comment for such cases.
Also, excluded and supported APIs are now tested for overlap.

This fixes #314 and #313