### PR TITLE
Diff after pushing

### DIFF
--- a/bin/auto-update/git.ts
+++ b/bin/auto-update/git.ts
@@ -184,6 +184,11 @@ export class Git {
       .filter(x => x.indexOf(TYPE_PREFIX) === 0);
   };
 
+  checkBranchExists = async (name: string): Promise<boolean> => {
+    const {stdout} = await this.sh.runSh(`git branch --list ${name}`);
+    return stdout.split('\n').find(x => x.trim() === name) !== undefined;
+  };
+
   checkBranchFormat = async (name: string): Promise<boolean> => {
     try {
       await this.sh.runSh(`git check-ref-format --branch ${name}`);

--- a/bin/auto-update/gitHelpers.ts
+++ b/bin/auto-update/gitHelpers.ts
@@ -83,7 +83,7 @@ export class GitHelpers {
     }
   };
 
-  pushAndOpenPRIfItDoesNotExist = async (
+  pushAndOpenPRIfItDoesNotExistAndIfNotOnlyRevisionChanged = async (
     gapiTypeName: string
   ): Promise<void> => {
     const {
@@ -102,7 +102,15 @@ export class GitHelpers {
       return;
     }
 
-    await this.git.push({branch: gapiTypeName, force: true}); // pushes to fork branch
+    if (await this.git.checkBranchExists(gapiTypeName)) {
+      // only push local branches created during this run
+      await this.git.push({branch: gapiTypeName, force: true}); // pushes to fork branch
+    }
+
+    if (await this.onlyRevisionChanged(gapiTypeName)) {
+      console.log(`Revision-only change for ${gapiTypeName}, skipping...`);
+      return;
+    }
 
     console.log(`Opening PR for ${gapiTypeName}...`);
 

--- a/bin/auto-update/index.ts
+++ b/bin/auto-update/index.ts
@@ -103,14 +103,13 @@ process.on('unhandledRejection', reason => {
   }
 
   for (const type of changedTypes) {
-    if (
-      supportedTypes.indexOf(type) === -1 ||
-      (await gitHelpers.onlyRevisionChanged(type))
-    ) {
+    if (supportedTypes.indexOf(type) === -1) {
       continue;
     }
 
-    await gitHelpers.pushAndOpenPRIfItDoesNotExist(type);
+    await gitHelpers.pushAndOpenPRIfItDoesNotExistAndIfNotOnlyRevisionChanged(
+      type
+    );
   }
 
   await gitHelpers.checkForTemplateUpdate();


### PR DESCRIPTION
Fixes #326 

<del>Since we're not pushing all branches, we should not compare local master with a remote branch (`origin/gapi.client....`). Instead, we should compare it with a local branch (`gapi.client....`).</del>
This is not true, because sometimes we may have changes in origin, but don't have them in a local branch, so there's no local branch at all. See https://github.com/Maxim-Mazurok/google-api-typings-generator/runs/1031094977?check_suite_focus=true

Instead, we should push and only then do diff, as usual.