### PR TITLE
docs: add TypeScript 6.0+ compatibility documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,40 @@ While we do generate typings for Google APIs, we can't generate `gapi` typings f
 
 The **server-side** libraries are open-sourced and are available [here](https://github.com/googleapis/google-api-nodejs-client). Since they are written in TS, you don't need any additional type definitions to use them.
 
+## TypeScript 6.0+ Compatibility
+
+TypeScript 6.0 changed the default value of the `types` compiler option from `undefined` (auto-include all `@types` packages) to `[]` (include none). This means the global `gapi.client.*` namespaces provided by our packages are no longer automatically available.
+
+### Fix: add types explicitly
+
+Add the required type packages to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "gapi.client.sheets-v4"]
+  }
+}
+```
+
+Replace `gapi.client.sheets-v4` with whichever API packages you use. You also need `gapi` and `gapi.client` for the base `gapi.load()` and `gapi.client.*` types.
+
+### Alternative: restore the old behavior
+
+If you prefer the pre-6.0 behavior where all `@types` packages are included automatically:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["*"]
+  }
+}
+```
+
+### Long-term
+
+Issue [#1276](https://github.com/Maxim-Mazurok/google-api-typings-generator/issues/1276) tracks migrating from global namespaces to module-based type definitions, which would eliminate the need for `types` configuration entirely.
+
 ## Troubleshooting
 
 ### npm install - 404 Not Found

--- a/src/template/readme.dot
+++ b/src/template/readme.dot
@@ -11,6 +11,18 @@ Install typings for {{=it.restDescription.title}}:
 npm install @types/{{=it.packageName}} --save-dev
 ```
 
+## TypeScript 6.0+
+
+TypeScript 6.0 changed `types` to default to `[]`. You must now explicitly list type packages in `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "{{=it.packageName}}"]
+  }
+}
+```
+
 ## Usage
 
 You need to initialize Google API client in your code:

--- a/test/__snapshots__/templates.spec.ts.snap
+++ b/test/__snapshots__/templates.spec.ts.snap
@@ -14,6 +14,18 @@ Install typings for My Types:
 npm install @types/my-name-v1beta --save-dev
 \`\`\`
 
+## TypeScript 6.0+
+
+TypeScript 6.0 changed \`types\` to default to \`[]\`. You must now explicitly list type packages in \`tsconfig.json\`:
+
+\`\`\`json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "my-name-v1beta"]
+  }
+}
+\`\`\`
+
 ## Usage
 
 You need to initialize Google API client in your code:

--- a/test/restDocs/__snapshots__/test.spec.ts.snap
+++ b/test/restDocs/__snapshots__/test.spec.ts.snap
@@ -11279,6 +11279,18 @@ Install typings for Admin SDK API:
 npm install @types/gapi.client.admin-directory_v1 --save-dev
 \`\`\`
 
+## TypeScript 6.0+
+
+TypeScript 6.0 changed \`types\` to default to \`[]\`. You must now explicitly list type packages in \`tsconfig.json\`:
+
+\`\`\`json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "gapi.client.admin-directory_v1"]
+  }
+}
+\`\`\`
+
 ## Usage
 
 You need to initialize Google API client in your code:
@@ -16816,6 +16828,18 @@ Install typings for Calendar API:
 npm install @types/gapi.client.calendar-v3 --save-dev
 \`\`\`
 
+## TypeScript 6.0+
+
+TypeScript 6.0 changed \`types\` to default to \`[]\`. You must now explicitly list type packages in \`tsconfig.json\`:
+
+\`\`\`json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "gapi.client.calendar-v3"]
+  }
+}
+\`\`\`
+
 ## Usage
 
 You need to initialize Google API client in your code:
@@ -22018,6 +22042,18 @@ Install typings for Drive API:
 
 \`\`\`
 npm install @types/gapi.client.drive-v3 --save-dev
+\`\`\`
+
+## TypeScript 6.0+
+
+TypeScript 6.0 changed \`types\` to default to \`[]\`. You must now explicitly list type packages in \`tsconfig.json\`:
+
+\`\`\`json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "gapi.client.drive-v3"]
+  }
+}
 \`\`\`
 
 ## Usage
@@ -34075,6 +34111,18 @@ Install typings for Application Integration API:
 
 \`\`\`
 npm install @types/gapi.client.integrations-v1 --save-dev
+\`\`\`
+
+## TypeScript 6.0+
+
+TypeScript 6.0 changed \`types\` to default to \`[]\`. You must now explicitly list type packages in \`tsconfig.json\`:
+
+\`\`\`json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "gapi.client.integrations-v1"]
+  }
+}
 \`\`\`
 
 ## Usage
@@ -47274,6 +47322,18 @@ Install typings for Google Sheets API:
 npm install @types/gapi.client.sheets-v4 --save-dev
 \`\`\`
 
+## TypeScript 6.0+
+
+TypeScript 6.0 changed \`types\` to default to \`[]\`. You must now explicitly list type packages in \`tsconfig.json\`:
+
+\`\`\`json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "gapi.client.sheets-v4"]
+  }
+}
+\`\`\`
+
 ## Usage
 
 You need to initialize Google API client in your code:
@@ -59483,6 +59543,18 @@ Install typings for Some Name:
 
 \`\`\`
 npm install @types/gapi.client.some-name-v1 --save-dev
+\`\`\`
+
+## TypeScript 6.0+
+
+TypeScript 6.0 changed \`types\` to default to \`[]\`. You must now explicitly list type packages in \`tsconfig.json\`:
+
+\`\`\`json
+{
+  "compilerOptions": {
+    "types": ["gapi", "gapi.auth2", "gapi.client", "gapi.client.some-name-v1"]
+  }
+}
 \`\`\`
 
 ## Usage


### PR DESCRIPTION
Ⓜ

## Summary

Add TypeScript 6.0+ compatibility documentation to help users who upgrade to TS 6.0 and encounter `Cannot find namespace 'gapi'` errors due to the `types` default changing from `undefined` to `[]`.

## Changes

- **README.md**: New "TypeScript 6.0+ Compatibility" section with explicit `types` configuration, wildcard alternative, and link to #1276 (module-based definitions long-term fix)
- **src/template/readme.dot**: Per-package README template now includes a "TypeScript 6.0+" section with the specific package name pre-filled in the `types` array
- Updated test snapshots to reflect the template change

Closes #1290
