### PR TITLE
build(deps): ignore typescript 7.0.x in dependabot, document path to 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,15 @@ updates:
       dt-stuff:
         patterns:
           - '@definitelytyped/*'
+    ignore:
+      # typescript 7.0.x ships no JS compiler API, which typescript-eslint
+      # (via gts) and @definitelytyped/dtslint still require, so `typescript`
+      # stays on 6.x and typescript 7 is consumed via the typescript-go alias.
+      # typescript 7.1 is expected to ship the new API, so only 7.0.x is
+      # ignored — dependabot will open a PR for 7.1+ and we re-assess then.
+      # See dependencyComments in package.json and PR #1356.
+      - dependency-name: 'typescript'
+        versions: ['7.0.x']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/cspell.json
+++ b/cspell.json
@@ -25,6 +25,7 @@
     "npmjs",
     "nvmrc",
     "octokit",
+    "oxlint",
     "packagejson",
     "poststart",
     "posttest",
@@ -33,6 +34,7 @@
     "PUNCSP",
     "readlines",
     "repos",
+    "tsgolint",
     "uncommenting",
     "Vong",
     "ZWSP"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencyComments": {
     "@definitelytyped/dtslint": "relies on @definitelytyped/eslint-plugin, update them together",
     "@definitelytyped/eslint-plugin": "needed for @definitelytyped/dtslint, update them together",
-    "typescript": "kept on 6.x because eslint-based tooling (gts, dtslint via typescript-eslint) requires the JS compiler API that typescript 7 (native compiler) no longer ships; typescript-eslint peer range is still <6.1",
-    "typescript-go": "typescript 7 native compiler, used for type-check (tsc --noEmit) and for extracting global type names from its lib.*.d.ts files; replace typescript with it once typescript-eslint and dtslint support 7"
+    "typescript": "kept on 6.x because eslint-based tooling (gts and dtslint, both via typescript-eslint) requires the JS compiler API that typescript 7.0 (native compiler) does not ship; dependabot ignores 7.0.x only — typescript 7.1 is expected to ship the new API and will open a PR, at which point re-assess: typescript-eslint adoption is tracked in typescript-eslint/typescript-eslint#10940 and dtslint peer range is still <7",
+    "typescript-go": "typescript 7 native compiler installed side-by-side (the officially recommended setup), used for type-check (tsc --noEmit) and for extracting global type names from its lib.*.d.ts files; once typescript-eslint and dtslint support 7, point typescript at 7 and drop this alias; if the eslint stack lags after 7.1, plan B is replacing gts/eslint with oxlint+tsgolint for our own linting, though dtslint alone still keeps typescript 6 around"
   }
 }


### PR DESCRIPTION
Follow-up to #1356.

**What**
- Dependabot now ignores `typescript` `7.0.x` only — without this it would re-open the failing 6.x → 7.0.x bump every Saturday (`npm ci` ERESOLVE on dtslint's `typescript@"<7"` peer).
- Deliberately **not** ignoring `>=7`: TypeScript 7.1 is expected to ship the new compiler API ([7.0 announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0)), so the 7.1 bump PR will come through and act as the trigger to re-assess.
- `dependencyComments` in package.json now documents the full plan and path forward.

**Re-assess checklist for when the 7.1 PR arrives**
1. typescript-eslint tsgo adoption: [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) (currently: "nothing we can do until stable API", thread locked)
2. `@definitelytyped/dtslint` peer range (currently `typescript@"<7"`; actively released — 0.2.42→0.2.46 May–Jul 2026 — so likely to move once DT adopts TS7)
3. If the eslint stack lags: plan B is replacing gts/eslint with [oxlint + tsgolint](https://github.com/oxc-project/tsgolint) (type-aware linting on native tsgo, active) for our own linting — note dtslint alone still keeps typescript 6 installed, so this buys speed, not the removal of TS6.

`typescript-go` (the TS7 alias) is unaffected — dependabot keeps bumping it through 7.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)